### PR TITLE
fix duplicated images on ImageFileDropzone

### DIFF
--- a/src/components/SortableList.tsx
+++ b/src/components/SortableList.tsx
@@ -55,7 +55,7 @@ const SortableList = SortableContainer(
       <Grid container spacing={1} className={classes.padding}>
         {items.map((item: any, index: number) => (
           <SortableItem
-            key={item.path ?? item.name ?? index}
+            key={index+item.path ?? index+item.name ?? index}
             order={index}
             index={index}
             item={item}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20438637/101324042-eb692900-38ac-11eb-8556-6ef59cfb75ab.png)
같은 이름의 이미지파일가 업로드되었을때 Non unique key에러로 드랍존에서 순서 변경하면 이미지가 중복되는 현상을 고쳤습니다